### PR TITLE
Handle test failure when no network connection

### DIFF
--- a/css_parser_tests/test_parse.py
+++ b/css_parser_tests/test_parse.py
@@ -10,9 +10,9 @@ import css_parser
 from . import basetest
 
 if sys.version_info.major > 2:
-    from urllib.error import HTTPError
+    from urllib.error import HTTPError, URLError
 else:
-    from urllib2 import HTTPError
+    from urllib2 import HTTPError, URLError
 
 
 class CSSParserTestCase(basetest.BaseTestCase):
@@ -142,7 +142,8 @@ class CSSParserTestCase(basetest.BaseTestCase):
 
         self.assertRaises(ValueError, parser.parseUrl,
                           '../not-valid-in-urllib')
-        self.assertRaises(HTTPError, parser.parseUrl,
+        # we'll get an URLError if no network connection
+        self.assertRaises((HTTPError, URLError), parser.parseUrl,
                           'http://cthedot.de/not-present.css')
 
     def test_parseString(self):


### PR DESCRIPTION
This allows the test to pass in a network-less build environment.

This is a partial fix only. A similar error occurs in `css_parser_tests/test_errorhandler.py`:
```
======================================================================
FAIL: test_handlers (css_parser_tests.test_errorhandler.ErrorHandlerTestCase)
css_parser.log
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/build/BUILD/css-parser-1.0.4/css_parser_tests/test_errorhandler.py", line 107, in test_handlers
    'ERROR    Expected "text/css" mime type')
AssertionError: u'' != u'ERROR    Expected "text/css" mime type'
+ ERROR    Expected "text/css" mime type

----------------------------------------------------------------------
Ran 394 tests in 4.496s

FAILED (failures=1)
```
But I don't know how to fix that one. I think that the test might be exposing a bug in the code, because the handler log is empty, no error about an unresolvable hostname is logged.