### PR TITLE
test: relax assertRaisesMsg to match longer strings

### DIFF
--- a/css_parser_tests/basetest.py
+++ b/css_parser_tests/basetest.py
@@ -149,21 +149,7 @@ class BaseTestCase(unittest.TestCase):
         else:
             self.fail("%s did not raise %s" % (callsig, exception))
 
-    def assertRaisesMsg(self, excClass, msg, callableObj, *args, **kwargs):
-        """
-        Just like unittest.TestCase.assertRaises,
-        but checks that the message is right too.
-
-        Usage::
-
-            self.assertRaisesMsg(
-                MyException, "Exception message",
-                my_function, (arg1, arg2)
-                )
-
-        from
-        http://www.nedbatchelder.com/blog/200609.html#e20060905T064418
-        """
+    def _assertRaisesMsgSubstring(self, excClass, msg, substring_match, callableObj, *args, **kwargs):
         try:
             callableObj(*args, **kwargs)
         except excClass as exc:
@@ -171,7 +157,7 @@ class BaseTestCase(unittest.TestCase):
             if not msg:
                 # No message provided: any message is fine.
                 return
-            elif excMsg == msg:
+            elif (msg in excMsg if substring_match else msg == excMsg):
                 # Message provided, and we got the right message: passes.
                 return
             else:
@@ -188,6 +174,29 @@ class BaseTestCase(unittest.TestCase):
                 "Expected to raise %s, didn't get an exception at all" %
                 excName
             )
+
+    def assertRaisesMsg(self, excClass, msg, callableObj, *args, **kwargs):
+        """
+        Just like unittest.TestCase.assertRaises,
+        but checks that the message is right too.
+
+        Usage::
+
+            self.assertRaisesMsg(
+                MyException, "Exception message",
+                my_function, arg1, arg2,
+                kwarg1=val, kwarg2=val)
+
+        from
+        http://www.nedbatchelder.com/blog/200609.html#e20060905T064418
+        """
+        return self._assertRaisesMsgSubstring(excClass, msg, False, callableObj, *args, **kwargs)
+
+    def assertRaisesMsgSubstring(self, excClass, msg, callableObj, *args, **kwargs):
+        """
+        Just like assertRaisesMsg, but looks for substring in the message.
+        """
+        return self._assertRaisesMsgSubstring(excClass, msg, True, callableObj, *args, **kwargs)
 
     def do_equal_p(self, tests, att='cssText', debug=False, raising=True):
         """

--- a/css_parser_tests/test_property.py
+++ b/css_parser_tests/test_property.py
@@ -162,8 +162,8 @@ class PropertyTestCase(basetest.BaseTestCase):
         "Property.literalname"
         p = css_parser.css.property.Property(r'c\olor', 'red')
         self.assertEqual(r'c\olor', p.literalname)
-        self.assertRaisesMsg(AttributeError, "can't set attribute", p.__setattr__,
-                             'literalname', 'color')
+        self.assertRaisesMsgSubstring(AttributeError, "can't set attribute", p.__setattr__,
+                                      'literalname', 'color')
 
     def test_validate(self):
         "Property.valid"

--- a/css_parser_tests/test_selector.py
+++ b/css_parser_tests/test_selector.py
@@ -412,7 +412,7 @@ class SelectorTestCase(basetest.BaseTestCase):
 
         # readonly
         def _set(): selector.specificity = 1
-        self.assertRaisesMsg(AttributeError, "can't set attribute", _set)
+        self.assertRaisesMsgSubstring(AttributeError, "can't set attribute", _set)
 
         tests = {
             '*': (0, 0, 0, 0),


### PR DESCRIPTION
With python3.10, we get the following failure:
```
======================================================================
FAIL: test_literalname (css_parser_tests.test_property.PropertyTestCase)
Property.literalname
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/build/BUILD/css-parser-1.0.6/css_parser_tests/basetest.py", line 168, in assertRaisesMsg
    callableObj(*args, **kwargs)
AttributeError: can't set attribute 'literalname'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/builddir/build/BUILD/css-parser-1.0.6/css_parser_tests/test_property.py", line 165, in test_literalname
    self.assertRaisesMsg(AttributeError, "can't set attribute", p.__setattr__,
  File "/builddir/build/BUILD/css-parser-1.0.6/css_parser_tests/basetest.py", line 179, in assertRaisesMsg
    raise self.failureException(
AssertionError: Right exception, wrong message: got 'can't set attribute 'literalname'' instead of 'can't set attribute'

======================================================================
FAIL: test_specificity (css_parser_tests.test_selector.SelectorTestCase)
Selector.specificity
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/builddir/build/BUILD/css-parser-1.0.6/css_parser_tests/basetest.py", line 168, in assertRaisesMsg
    callableObj(*args, **kwargs)
  File "/builddir/build/BUILD/css-parser-1.0.6/css_parser_tests/test_selector.py", line 414, in _set
    def _set(): selector.specificity = 1
AttributeError: can't set attribute 'specificity'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/builddir/build/BUILD/css-parser-1.0.6/css_parser_tests/test_selector.py", line 415, in test_specificity
    self.assertRaisesMsg(AttributeError, "can't set attribute", _set)
  File "/builddir/build/BUILD/css-parser-1.0.6/css_parser_tests/basetest.py", line 179, in assertRaisesMsg
    raise self.failureException(
AssertionError: Right exception, wrong message: got 'can't set attribute 'specificity'' instead of 'can't set attribute'

----------------------------------------------------------------------
```

By checking if the argument matches just a substring, we can match
those cases without making the code more complicated. Matching just
for substrings in exception messages is pretty common.