### PR TITLE
Replace removed assertEquals with assertEqual

### DIFF
--- a/css_parser_tests/basetest.py
+++ b/css_parser_tests/basetest.py
@@ -261,7 +261,7 @@ class GenerateTests(type):
     Example::
 
         def gen_test_length(self, string, expected):
-            self.assertEquals(len(string), expected)
+            self.assertEqual(len(string), expected)
         gen_test_length.cases = [
             ("a", 1),
             ("aa", 2),

--- a/css_parser_tests/basetest.py
+++ b/css_parser_tests/basetest.py
@@ -131,10 +131,11 @@ class BaseTestCase(unittest.TestCase):
             callable(*args, **kwargs)
         except exception as exc:
             if exc_args is not None:
-                self.failIf(exc.args != exc_args,
-                            "%s raised %s with unexpected args: "
-                            "expected=%r, actual=%r"
-                            % (callsig, exc.__class__, exc_args, exc.args))
+                self.assertEqual(
+                    exc.args,
+                    exc_args,
+                    '%s raised %s with unexpected args: expected=%r, actual=%r' % (callsig, exc.__class__, exc_args, exc.args)
+                )
             if exc_pattern is not None:
                 self.assertTrue(exc_pattern.search(str(exc)),
                                 "%s raised %s, but the exception "

--- a/css_parser_tests/test_codec.py
+++ b/css_parser_tests/test_codec.py
@@ -117,10 +117,10 @@ class CodecTestCase(unittest.TestCase):
     def test_fixencoding(self):
         "codec._fixencoding()"
         s = '@charset "'
-        self.assertTrue(codec._fixencoding(s, "utf-8") is None)
+        self.assertIsNone(codec._fixencoding(s, 'utf-8'))
 
         s = '@charset "x'
-        self.assertTrue(codec._fixencoding(s, "utf-8") is None)
+        self.assertIsNone(codec._fixencoding(s, 'utf-8'))
 
         s = '@charset "x'
         self.assertEqual(codec._fixencoding(s, "utf-8", True), s)

--- a/css_parser_tests/test_csscharsetrule.py
+++ b/css_parser_tests/test_csscharsetrule.py
@@ -107,7 +107,7 @@ class CSSCharsetRuleTestCase(test_cssrule.CSSRuleTestCase):
     def test_repr(self):
         "CSSCharsetRule.__repr__()"
         self.r.encoding = 'utf-8'
-        self.assertTrue('utf-8' in repr(self.r))
+        self.assertIn('utf-8', repr(self.r))
 
     def test_reprANDstr(self):
         "CSSCharsetRule.__repr__(), .__str__()"
@@ -115,11 +115,11 @@ class CSSCharsetRuleTestCase(test_cssrule.CSSRuleTestCase):
 
         s = css_parser.css.CSSCharsetRule(encoding=encoding)
 
-        self.assertTrue(encoding in str(s))
+        self.assertIn(encoding, str(s))
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
-        self.assertTrue(encoding == s2.encoding)
+        self.assertIsInstance(s2, s.__class__)
+        self.assertEqual(encoding, s2.encoding)
 
 
 if __name__ == '__main__':

--- a/css_parser_tests/test_csscomment.py
+++ b/css_parser_tests/test_csscomment.py
@@ -66,8 +66,8 @@ class CSSCommentTestCase(test_cssrule.CSSRuleTestCase):
         s = css_parser.css.CSSComment(cssText=text)
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
-        self.assertTrue(text == s2.cssText)
+        self.assertIsInstance(s2, s.__class__)
+        self.assertEqual(text, s2.cssText)
 
 
 if __name__ == '__main__':

--- a/css_parser_tests/test_cssfontfacerule.py
+++ b/css_parser_tests/test_cssfontfacerule.py
@@ -21,7 +21,7 @@ class CSSFontFaceRuleTestCase(test_cssrule.CSSRuleTestCase):
         super(CSSFontFaceRuleTestCase, self).test_init()
 
         r = css_parser.css.CSSFontFaceRule()
-        self.assertTrue(isinstance(r.style, css_parser.css.CSSStyleDeclaration))
+        self.assertIsInstance(r.style, css_parser.css.CSSStyleDeclaration)
         self.assertEqual(r, r.style.parentRule)
 
         # until any properties
@@ -232,11 +232,11 @@ class CSSFontFaceRuleTestCase(test_cssrule.CSSRuleTestCase):
         style = 'src: url(x)'
         s = css_parser.css.CSSFontFaceRule(style=style)
 
-        self.assertTrue(style in str(s))
+        self.assertIn(style, str(s))
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
-        self.assertTrue(style == s2.style.cssText)
+        self.assertIsInstance(s2, s.__class__)
+        self.assertEqual(style, s2.style.cssText)
 
 
 if __name__ == '__main__':

--- a/css_parser_tests/test_cssimportrule.py
+++ b/css_parser_tests/test_cssimportrule.py
@@ -428,14 +428,14 @@ class CSSImportRuleTestCase(test_cssrule.CSSRuleTestCase):
         s = css_parser.css.CSSImportRule(href=href, mediaText=mediaText, name=name)
 
         # str(): mediaText nor name are present here
-        self.assertTrue(href in str(s))
+        self.assertIn(href, str(s))
 
         # repr()
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
-        self.assertTrue(href == s2.href)
-        self.assertTrue(mediaText == s2.media.mediaText)
-        self.assertTrue(name == s2.name)
+        self.assertIsInstance(s2, s.__class__)
+        self.assertEqual(href, s2.href)
+        self.assertEqual(mediaText, s2.media.mediaText)
+        self.assertEqual(name, s2.name)
 
 
 if __name__ == '__main__':

--- a/css_parser_tests/test_cssmediarule.py
+++ b/css_parser_tests/test_cssmediarule.py
@@ -439,11 +439,11 @@ class CSSMediaRuleTestCase(test_cssrule.CSSRuleTestCase):
 
         s = css_parser.css.CSSMediaRule(mediaText=mediaText)
 
-        self.assertTrue(mediaText in str(s))
+        self.assertIn(mediaText, str(s))
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
-        self.assertTrue(mediaText == s2.media.mediaText)
+        self.assertIsInstance(s2, s.__class__)
+        self.assertEqual(mediaText, s2.media.mediaText)
 
 
 if __name__ == '__main__':

--- a/css_parser_tests/test_cssnamespacerule.py
+++ b/css_parser_tests/test_cssnamespacerule.py
@@ -222,13 +222,13 @@ class CSSNamespaceRuleTestCase(test_cssrule.CSSRuleTestCase):
 
         s = css_parser.css.CSSNamespaceRule(namespaceURI=namespaceURI, prefix=prefix)
 
-        self.assertTrue(namespaceURI in str(s))
-        self.assertTrue(prefix in str(s))
+        self.assertIn(namespaceURI, str(s))
+        self.assertIn(prefix, str(s))
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
-        self.assertTrue(namespaceURI == s2.namespaceURI)
-        self.assertTrue(prefix == s2.prefix)
+        self.assertIsInstance(s2, s.__class__)
+        self.assertEqual(namespaceURI, s2.namespaceURI)
+        self.assertEqual(prefix, s2.prefix)
 
 
 if __name__ == '__main__':

--- a/css_parser_tests/test_csspagerule.py
+++ b/css_parser_tests/test_csspagerule.py
@@ -422,11 +422,11 @@ class CSSPageRuleTestCase(test_cssrule.CSSRuleTestCase):
 
         s = css_parser.css.CSSPageRule(selectorText=sel)
 
-        self.assertTrue(sel in str(s))
+        self.assertIn(sel, str(s))
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
-        self.assertTrue(sel == s2.selectorText)
+        self.assertIsInstance(s2, s.__class__)
+        self.assertEqual(sel, s2.selectorText)
 
 
 if __name__ == '__main__':

--- a/css_parser_tests/test_cssstyledeclaration.py
+++ b/css_parser_tests/test_cssstyledeclaration.py
@@ -64,11 +64,11 @@ class CSSStyleDeclarationTestCase(basetest.BaseTestCase):
         "CSSStyleDeclaration.__contains__(nameOrProperty)"
         s = css_parser.css.CSSStyleDeclaration(cssText=r'x: 1;\y: 2')
         for test in ('x', r'x', 'y', r'y'):
-            self.assertTrue(test in s)
-            self.assertTrue(test.upper() in s)
-            self.assertTrue(css_parser.css.Property(test, '1') in s)
-        self.assertTrue('z' not in s)
-        self.assertTrue(css_parser.css.Property('z', '1') not in s)
+            self.assertIn(test, s)
+            self.assertIn(test.upper(), s)
+            self.assertIn(css_parser.css.Property(test, '1'), s)
+        self.assertNotIn('z', s)
+        self.assertNotIn(css_parser.css.Property('z', '1'), s)
 
     def test__iter__item(self):
         "CSSStyleDeclaration.__iter__ and .item"
@@ -584,10 +584,10 @@ color: green;''': 'voice-family: inherit;\ncolor: green',
         "CSSStyleDeclaration.__repr__(), .__str__()"
         s = css_parser.css.CSSStyleDeclaration(cssText='a:1;b:2')
 
-        self.assertTrue("2" in str(s))  # length
+        self.assertIn('2', str(s)) # length
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
+        self.assertIsInstance(s2, s.__class__)
 
     def test_valid(self):
         "CSSStyleDeclaration.valid"

--- a/css_parser_tests/test_cssstylerule.py
+++ b/css_parser_tests/test_cssstylerule.py
@@ -241,11 +241,11 @@ class CSSStyleRuleTestCase(test_cssrule.CSSRuleTestCase):
 
         s = css_parser.css.CSSStyleRule(selectorText=sel)
 
-        self.assertTrue(sel in str(s))
+        self.assertIn(sel, str(s))
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
-        self.assertTrue(sel == s2.selectorText)
+        self.assertIsInstance(s2, s.__class__)
+        self.assertEqual(sel, s2.selectorText)
 
     def test_valid(self):
         "CSSStyleRule.valid"

--- a/css_parser_tests/test_cssstylesheet.py
+++ b/css_parser_tests/test_cssstylesheet.py
@@ -322,9 +322,9 @@ ex2|x {
                          {'': 'default', 'ex2': 'example'})
 
         # __contains__
-        self.assertTrue('' in s.namespaces)
-        self.assertTrue('ex2' in s.namespaces)
-        self.assertFalse('NOTSET' in s.namespaces)
+        self.assertIn('', s.namespaces)
+        self.assertIn('ex2', s.namespaces)
+        self.assertNotIn('NOTSET', s.namespaces)
         # __delitem__
         self.assertRaises(xml.dom.NoModificationAllowedErr,
                           s.namespaces.__delitem__, 'ex2')
@@ -450,7 +450,7 @@ ex2|SEL4, a, ex2|SELSR {
         self.assertRaises(xml.dom.NamespaceErr, s.add, css)
 
         s.add('@namespace x "html";')
-        self.assertTrue(s.namespaces['x'] == 'html')
+        self.assertEqual(s.namespaces['x'], 'html')
 
         r = css_parser.css.CSSStyleRule()
         r.cssText = ((css, {'h': 'html'}))
@@ -871,13 +871,13 @@ body {
 
         s = css_parser.css.CSSStyleSheet(href=href, title=title)
 
-        self.assertTrue(href in str(s))
-        self.assertTrue(title in str(s))
+        self.assertIn(href, str(s))
+        self.assertIn(title, str(s))
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
-        self.assertTrue(href == s2.href)
-        self.assertTrue(title == s2.title)
+        self.assertIsInstance(s2, s.__class__)
+        self.assertEqual(href, s2.href)
+        self.assertEqual(title, s2.title)
 
     def test_valid(self):
         cases = [

--- a/css_parser_tests/test_cssunknownrule.py
+++ b/css_parser_tests/test_cssunknownrule.py
@@ -146,7 +146,7 @@ class CSSUnknownRuleTestCase(test_cssrule.CSSRuleTestCase):
         s = css_parser.css.CSSUnknownRule(cssText='@x;')
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
+        self.assertIsInstance(s2, s.__class__)
 
 
 if __name__ == '__main__':

--- a/css_parser_tests/test_cssutils.py
+++ b/css_parser_tests/test_cssutils.py
@@ -63,7 +63,7 @@ class CSSutilsTestCase(basetest.BaseTestCase):
         "css_parser.parseString()"
         s = css_parser.parseString(
             self.exp, media='handheld, screen', title='from string')
-        self.assertTrue(isinstance(s, css_parser.css.CSSStyleSheet))
+        self.assertIsInstance(s, css_parser.css.CSSStyleSheet)
         self.assertEqual(None, s.href)
         self.assertEqual(self.exp.encode(), s.cssText)
         self.assertEqual('utf-8', s.encoding)
@@ -84,7 +84,7 @@ class CSSutilsTestCase(basetest.BaseTestCase):
         ir = s.cssRules[0]
         self.assertEqual('import/import2.css', ir.href)
         irs = ir.styleSheet
-        self.assertTrue(isinstance(irs, css_parser.css.CSSStyleSheet))
+        self.assertIsInstance(irs, css_parser.css.CSSStyleSheet)
         self.assertEqual(
             irs.cssText,
             '@import "../import3.css";\n@import "import-impossible.css" print;\n.import2 {\n    /* sheets/import2.css */\n    background: url(http://example.com/images/example.gif);\n    background: url(//example.com/images/example.gif);\n    background: url(/images/example.gif);\n    background: url(images2/example.gif);\n    background: url(./images2/example.gif);\n    background: url(../images/example.gif);\n    background: url(./../images/example.gif)\n    }'  # noqa
@@ -103,7 +103,7 @@ class CSSutilsTestCase(basetest.BaseTestCase):
         href = css_parser.helper.path2url(name)
         s = css_parser.parseFile(
             name, href=href, media='screen', title='from file')
-        self.assertTrue(isinstance(s, css_parser.css.CSSStyleSheet))
+        self.assertIsInstance(s, css_parser.css.CSSStyleSheet)
         if sys.platform.startswith('java'):
             # on Jython only file:
             self.assertTrue(s.href.startswith('file:'))
@@ -119,7 +119,7 @@ class CSSutilsTestCase(basetest.BaseTestCase):
         ir = s.cssRules[0]
         self.assertEqual('import/import2.css', ir.href)
         irs = ir.styleSheet
-        self.assertTrue(isinstance(irs, css_parser.css.CSSStyleSheet))
+        self.assertIsInstance(irs, css_parser.css.CSSStyleSheet)
         self.assertEqual(
             irs.cssText,
             '@import "../import3.css";\n@import "import-impossible.css" print;\n.import2 {\n    /* sheets/import2.css */\n    background: url(http://example.com/images/example.gif);\n    background: url(//example.com/images/example.gif);\n    background: url(/images/example.gif);\n    background: url(images2/example.gif);\n    background: url(./images2/example.gif);\n    background: url(../images/example.gif);\n    background: url(./../images/example.gif)\n    }'  # noqa
@@ -131,7 +131,7 @@ class CSSutilsTestCase(basetest.BaseTestCase):
         name = basetest.get_sheet_filename('import.css')
 
         s = css_parser.parseFile(name, media='screen', title='from file')
-        self.assertTrue(isinstance(s, css_parser.css.CSSStyleSheet))
+        self.assertIsInstance(s, css_parser.css.CSSStyleSheet)
         if sys.platform.startswith('java'):
             # on Jython only file:
             self.assertTrue(s.href.startswith('file:'))
@@ -147,7 +147,7 @@ class CSSutilsTestCase(basetest.BaseTestCase):
         ir = s.cssRules[0]
         self.assertEqual('import/import2.css', ir.href)
         irs = ir.styleSheet
-        self.assertTrue(isinstance(irs, css_parser.css.CSSStyleSheet))
+        self.assertIsInstance(irs, css_parser.css.CSSStyleSheet)
         self.assertEqual(
             irs.cssText,
             '@import "../import3.css";\n@import "import-impossible.css" print;\n.import2 {\n    /* sheets/import2.css */\n    background: url(http://example.com/images/example.gif);\n    background: url(//example.com/images/example.gif);\n    background: url(/images/example.gif);\n    background: url(images2/example.gif);\n    background: url(./images2/example.gif);\n    background: url(../images/example.gif);\n    background: url(./../images/example.gif)\n    }'  # noqa
@@ -201,7 +201,7 @@ class CSSutilsTestCase(basetest.BaseTestCase):
         href = css_parser.helper.path2url(href)
         # href = 'http://seewhatever.de/sheets/import.css'
         s = css_parser.parseUrl(href, media='tv, print', title='from url')
-        self.assertTrue(isinstance(s, css_parser.css.CSSStyleSheet))
+        self.assertIsInstance(s, css_parser.css.CSSStyleSheet)
         self.assertEqual(href, s.href)
         self.assertEqual(self.exp.encode(), s.cssText)
         self.assertEqual('utf-8', s.encoding)

--- a/css_parser_tests/test_cssvariablesdeclaration.py
+++ b/css_parser_tests/test_cssvariablesdeclaration.py
@@ -37,10 +37,10 @@ class CSSVariablesDeclarationTestCase(basetest.BaseTestCase):
         "CSSVariablesDeclaration.__contains__(name)"
         v = css_parser.css.CSSVariablesDeclaration(cssText='x: 0; y: 2')
         for test in ('x', 'y'):
-            self.assertTrue(test in v)
-            self.assertTrue(test.upper() in v)
+            self.assertIn(test, v)
+            self.assertIn(test.upper(), v)
 
-        self.assertTrue('z' not in v)
+        self.assertNotIn('z', v)
 
     def test_items(self):
         "CSSVariablesDeclaration[variableName]"
@@ -339,10 +339,10 @@ a {
         "CSSVariablesDeclaration.__repr__(), .__str__()"
         s = css_parser.css.CSSVariablesDeclaration(cssText='a:1;b:2')
 
-        self.assertTrue("2" in str(s))  # length
+        self.assertIn('2', str(s)) # length
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
+        self.assertIsInstance(s2, s.__class__)
 
 
 if __name__ == '__main__':

--- a/css_parser_tests/test_cssvariablesrule.py
+++ b/css_parser_tests/test_cssvariablesrule.py
@@ -145,11 +145,11 @@ class CSSVariablesRuleTestCase(test_cssrule.CSSRuleTestCase):
         "CSSVariablesRule.__repr__(), .__str__()"
         r = css_parser.css.CSSVariablesRule()
         r.cssText = '@variables { xxx: 1 }'
-        self.assertTrue('xxx' in str(r))
+        self.assertIn('xxx', str(r))
 
         r2 = eval(repr(r))
-        self.assertTrue(isinstance(r2, r.__class__))
-        self.assertTrue(r.cssText == r2.cssText)
+        self.assertIsInstance(r2, r.__class__)
+        self.assertEqual(r.cssText, r2.cssText)
 
 
 if __name__ == '__main__':

--- a/css_parser_tests/test_domimplementation.py
+++ b/css_parser_tests/test_domimplementation.py
@@ -24,12 +24,12 @@ class DOMImplementationTestCase(unittest.TestCase):
     def test_createDocument(self):
         "DOMImplementationCSS.createDocument()"
         doc = self.domimpl.createDocument(None, None, None)
-        self.assertTrue(isinstance(doc, xml.dom.minidom.Document))
+        self.assertIsInstance(doc, xml.dom.minidom.Document)
 
     def test_createDocumentType(self):
         "DOMImplementationCSS.createDocumentType()"
         doctype = self.domimpl.createDocumentType('foo', 'bar', 'raboof')
-        self.assertTrue(isinstance(doctype, xml.dom.minidom.DocumentType))
+        self.assertIsInstance(doctype, xml.dom.minidom.DocumentType)
 
     def test_hasFeature(self):
         "DOMImplementationCSS.hasFeature()"

--- a/css_parser_tests/test_marginrule.py
+++ b/css_parser_tests/test_marginrule.py
@@ -88,11 +88,11 @@ class MarginRuleTestCase(test_cssrule.CSSRuleTestCase):
 
         s = css_parser.css.MarginRule(margin=margin, style='left: 0')
 
-        self.assertTrue(margin in str(s))
+        self.assertIn(margin, str(s))
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
-        self.assertTrue(margin == s2.margin)
+        self.assertIsInstance(s2, s.__class__)
+        self.assertEqual(margin, s2.margin)
 
 
 if __name__ == '__main__':

--- a/css_parser_tests/test_medialist.py
+++ b/css_parser_tests/test_medialist.py
@@ -193,11 +193,11 @@ class MediaListTestCase(basetest.BaseTestCase):
 
         s = css_parser.stylesheets.MediaList(mediaText=mediaText)
 
-        self.assertTrue(mediaText in str(s))
+        self.assertIn(mediaText, str(s))
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
-        self.assertTrue(mediaText == s2.mediaText)
+        self.assertIsInstance(s2, s.__class__)
+        self.assertEqual(mediaText, s2.mediaText)
 
 
 if __name__ == '__main__':

--- a/css_parser_tests/test_mediaquery.py
+++ b/css_parser_tests/test_mediaquery.py
@@ -97,10 +97,10 @@ class MediaQueryTestCase(basetest.BaseTestCase):
         "MediaQuery.__repr__(), .__str__()"
         mediaText = 'tv and (color)'
         s = css_parser.stylesheets.MediaQuery(mediaText=mediaText)
-        self.assertTrue(mediaText in str(s))
+        self.assertIn(mediaText, str(s))
         s2 = eval(repr(s))
         self.assertEqual(mediaText, s2.mediaText)
-        self.assertTrue(isinstance(s2, s.__class__))
+        self.assertIsInstance(s2, s.__class__)
 
 
 if __name__ == '__main__':

--- a/css_parser_tests/test_property.py
+++ b/css_parser_tests/test_property.py
@@ -259,15 +259,15 @@ class PropertyTestCase(basetest.BaseTestCase):
 
         s = css_parser.css.property.Property(name=name, value=value, priority=priority)
 
-        self.assertTrue(name in str(s))
-        self.assertTrue(value in str(s))
-        self.assertTrue(priority in str(s))
+        self.assertIn(name, str(s))
+        self.assertIn(value, str(s))
+        self.assertIn(priority, str(s))
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
-        self.assertTrue(name == s2.name)
-        self.assertTrue(value == s2.value)
-        self.assertTrue(priority == s2.priority)
+        self.assertIsInstance(s2, s.__class__)
+        self.assertEqual(name, s2.name)
+        self.assertEqual(value, s2.value)
+        self.assertEqual(priority, s2.priority)
 
 
 if __name__ == '__main__':

--- a/css_parser_tests/test_selector.py
+++ b/css_parser_tests/test_selector.py
@@ -486,11 +486,11 @@ class SelectorTestCase(basetest.BaseTestCase):
 
         s = css_parser.css.Selector(selectorText=sel)
 
-        self.assertTrue(sel in str(s))
+        self.assertIn(sel, str(s))
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
-        self.assertTrue(sel == s2.selectorText)
+        self.assertIsInstance(s2, s.__class__)
+        self.assertEqual(sel, s2.selectorText)
 
 
 if __name__ == '__main__':

--- a/css_parser_tests/test_selectorlist.py
+++ b/css_parser_tests/test_selectorlist.py
@@ -139,10 +139,10 @@ class SelectorListTestCase(basetest.BaseTestCase):
 
         s = css_parser.css.SelectorList(selectorText=sel)
 
-        self.assertTrue(sel[0] in str(s))
+        self.assertIn(sel[0], str(s))
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
+        self.assertIsInstance(s2, s.__class__)
         self.assertEqual(sel[0], s2.selectorText)
 
 

--- a/css_parser_tests/test_util.py
+++ b/css_parser_tests/test_util.py
@@ -442,12 +442,12 @@ class TestLazyRegex(basetest.BaseTestCase):
     def test_calling(self):
         self.assertIsNone(self.lazyre('bar'))
         match = self.lazyre('foobar')
-        self.assertEquals(match.group(), 'foo')
+        self.assertEqual(match.group(), 'foo')
 
     def test_matching(self):
         self.assertIsNone(self.lazyre.match('bar'))
         match = self.lazyre.match('foobar')
-        self.assertEquals(match.group(), 'foo')
+        self.assertEqual(match.group(), 'foo')
 
     def test_matching_with_position_parameters(self):
         self.assertIsNone(self.lazyre.match('foo', 1))
@@ -456,56 +456,56 @@ class TestLazyRegex(basetest.BaseTestCase):
     def test_searching(self):
         self.assertIsNone(self.lazyre.search('rafuubar'))
         match = self.lazyre.search('rafoobar')
-        self.assertEquals(match.group(), 'foo')
+        self.assertEqual(match.group(), 'foo')
 
     def test_searching_with_position_parameters(self):
         self.assertIsNone(self.lazyre.search('rafoobar', 3))
         self.assertIsNone(self.lazyre.search('rafoobar', 0, 4))
         match = self.lazyre.search('rafoofuobar', 4)
-        self.assertEquals(match.group(), 'fuo')
+        self.assertEqual(match.group(), 'fuo')
 
     def test_split(self):
-        self.assertEquals(self.lazyre.split('rafoobarfoobaz'),
+        self.assertEqual(self.lazyre.split('rafoobarfoobaz'),
                           ['ra', 'bar', 'baz'])
-        self.assertEquals(self.lazyre.split('rafoobarfoobaz', 1),
+        self.assertEqual(self.lazyre.split('rafoobarfoobaz', 1),
                           ['ra', 'barfoobaz'])
 
     def test_findall(self):
-        self.assertEquals(self.lazyre.findall('rafoobarfuobaz'),
+        self.assertEqual(self.lazyre.findall('rafoobarfuobaz'),
                           ['foo', 'fuo'])
 
     def test_finditer(self):
         result = self.lazyre.finditer('rafoobarfuobaz')
-        self.assertEquals([m.group() for m in result], ['foo', 'fuo'])
+        self.assertEqual([m.group() for m in result], ['foo', 'fuo'])
 
     def test_sub(self):
-        self.assertEquals(self.lazyre.sub('bar', 'foofoo'), 'barbar')
-        self.assertEquals(self.lazyre.sub(lambda x: 'baz', 'foofoo'), 'bazbaz')
+        self.assertEqual(self.lazyre.sub('bar', 'foofoo'), 'barbar')
+        self.assertEqual(self.lazyre.sub(lambda x: 'baz', 'foofoo'), 'bazbaz')
 
     def test_subn(self):
         subbed = self.lazyre.subn('bar', 'foofoo')
-        self.assertEquals(subbed, ('barbar', 2))
+        self.assertEqual(subbed, ('barbar', 2))
         subbed = self.lazyre.subn(lambda x: 'baz', 'foofoo')
-        self.assertEquals(subbed, ('bazbaz', 2))
+        self.assertEqual(subbed, ('bazbaz', 2))
 
     def test_groups(self):
         lazyre = LazyRegex('(.)(.)')
         self.assertIsNone(lazyre.groups)
         lazyre.ensure()
-        self.assertEquals(lazyre.groups, 2)
+        self.assertEqual(lazyre.groups, 2)
 
     def test_groupindex(self):
         lazyre = LazyRegex('(?P<foo>.)')
         self.assertIsNone(lazyre.groupindex)
         lazyre.ensure()
-        self.assertEquals(lazyre.groupindex, {'foo': 1})
+        self.assertEqual(lazyre.groupindex, {'foo': 1})
 
     def test_flags(self):
         self.lazyre.ensure()
-        self.assertEquals(self.lazyre.flags, re.compile('.').flags)
+        self.assertEqual(self.lazyre.flags, re.compile('.').flags)
 
     def test_pattern(self):
-        self.assertEquals(self.lazyre.pattern, 'f.o')
+        self.assertEqual(self.lazyre.pattern, 'f.o')
 
 
 if __name__ == '__main__':

--- a/css_parser_tests/test_value.py
+++ b/css_parser_tests/test_value.py
@@ -358,10 +358,10 @@ class PropertyValueTestCase(basetest.BaseTestCase):
     def test_readonly(self):
         "PropertyValue._readonly"
         v = css_parser.css.PropertyValue(cssText='inherit')
-        self.assertTrue(False is v._readonly)
+        self.assertIs(False, v._readonly)
 
         v = css_parser.css.PropertyValue(cssText='inherit', readonly=True)
-        self.assertTrue(True is v._readonly)
+        self.assertIs(True, v._readonly)
         self.assertTrue('inherit', v.cssText)
         self.assertRaises(xml.dom.NoModificationAllowedErr, v._setCssText, 'x')
         self.assertTrue('inherit', v.cssText)
@@ -372,11 +372,11 @@ class PropertyValueTestCase(basetest.BaseTestCase):
 
         s = css_parser.css.PropertyValue(cssText=cssText)
 
-        self.assertTrue(cssText in str(s))
+        self.assertIn(cssText, str(s))
 
         s2 = eval(repr(s))
-        self.assertTrue(isinstance(s2, s.__class__))
-        self.assertTrue(cssText == s2.cssText)
+        self.assertIsInstance(s2, s.__class__)
+        self.assertEqual(cssText, s2.cssText)
 
 
 class ValueTestCase(basetest.BaseTestCase):
@@ -384,9 +384,9 @@ class ValueTestCase(basetest.BaseTestCase):
     def test_init(self):
         "Value.__init__()"
         v = css_parser.css.Value()
-        self.assertTrue('' == v.cssText)
-        self.assertTrue('' == v.value)
-        self.assertTrue(None is v.type)
+        self.assertEqual('', v.cssText)
+        self.assertEqual('', v.value)
+        self.assertIs(None, v.type)
 
     def test_cssText(self):
         "Value.cssText"
@@ -425,8 +425,8 @@ class ColorValueTestCase(basetest.BaseTestCase):
         "ColorValue.__init__()"
         v = css_parser.css.ColorValue()
         self.assertEqual(v.COLOR_VALUE, v.type)
-        self.assertTrue('' == v.cssText)
-        self.assertTrue('' == v.value)
+        self.assertEqual('', v.cssText)
+        self.assertEqual('', v.value)
         self.assertEqual('transparent', v.name)
         self.assertEqual(None, v.colorType)
 
@@ -532,19 +532,19 @@ class URIValueTestCase(basetest.BaseTestCase):
     def test_init(self):
         "URIValue.__init__()"
         v = css_parser.css.URIValue()
-        self.assertTrue('url()' == v.cssText)
-        self.assertTrue('' == v.value)
-        self.assertTrue('' == v.uri)
-        self.assertTrue(v.URI is v.type)
+        self.assertEqual('url()', v.cssText)
+        self.assertEqual('', v.value)
+        self.assertEqual('', v.uri)
+        self.assertIs(v.URI, v.type)
 
         v.uri = '1'
-        self.assertTrue('1' == v.value)
-        self.assertTrue('1' == v.uri)
+        self.assertEqual('1', v.value)
+        self.assertEqual('1', v.uri)
         self.assertEqual('url(1)', v.cssText)
 
         v.value = '2'
-        self.assertTrue('2' == v.value)
-        self.assertTrue('2' == v.uri)
+        self.assertEqual('2', v.value)
+        self.assertEqual('2', v.uri)
         self.assertEqual('url(2)', v.cssText)
 
     def test_absoluteUri(self):
@@ -601,10 +601,10 @@ class DimensionValueTestCase(basetest.BaseTestCase):
     def test_init(self):
         "DimensionValue.__init__()"
         v = css_parser.css.DimensionValue()
-        self.assertTrue('' == v.cssText)
-        self.assertTrue('' == v.value)
-        self.assertTrue(None is v.type)
-        self.assertTrue(None is v.dimension)
+        self.assertEqual('', v.cssText)
+        self.assertEqual('', v.value)
+        self.assertIs(None, v.type)
+        self.assertIs(None, v.dimension)
 
     def test_cssText(self):
         "DimensionValue.cssText"
@@ -696,8 +696,8 @@ class CSSVariableTestCase(basetest.BaseTestCase):
         v = css_parser.css.CSSVariable()
         self.assertEqual('', v.cssText)
         self.assertEqual('VARIABLE', v.type)
-        self.assertTrue(None is v.name)
-        self.assertTrue(None is v.value)
+        self.assertIs(None, v.name)
+        self.assertIs(None, v.value)
 
     def test_cssText(self):
         "CSSVariable.cssText"


### PR DESCRIPTION
In Python 3.11, the deprecated `assertEquals` has been removed. Use `assertEqual` instead.

This also upgrades other unittest asserts to give better error messages.