### PR TITLE
Replace non-standard own-made assert methods by the standard ones

### DIFF
--- a/css_parser_tests/basetest.py
+++ b/css_parser_tests/basetest.py
@@ -107,49 +107,6 @@ class BaseTestCase(unittest.TestCase):
         if hasattr(self, '_ser'):
             self._restoreSer()
 
-    def assertRaisesEx(self, exception, callable, *args, **kwargs):
-        """
-        from
-        http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/307970
-        """
-        if "exc_args" in kwargs:
-            exc_args = kwargs["exc_args"]
-            del kwargs["exc_args"]
-        else:
-            exc_args = None
-        if "exc_pattern" in kwargs:
-            exc_pattern = kwargs["exc_pattern"]
-            del kwargs["exc_pattern"]
-        else:
-            exc_pattern = None
-
-        argv = [repr(a) for a in args]\
-            + ["%s=%r" % (k, v) for k, v in kwargs.items()]
-        callsig = "%s(%s)" % (callable.__name__, ", ".join(argv))
-
-        try:
-            callable(*args, **kwargs)
-        except exception as exc:
-            if exc_args is not None:
-                self.assertEqual(
-                    exc.args,
-                    exc_args,
-                    '%s raised %s with unexpected args: expected=%r, actual=%r' % (callsig, exc.__class__, exc_args, exc.args)
-                )
-            if exc_pattern is not None:
-                self.assertTrue(exc_pattern.search(str(exc)),
-                                "%s raised %s, but the exception "
-                                "does not match '%s': %r"
-                                % (callsig, exc.__class__, exc_pattern.pattern,
-                                   str(exc)))
-        except Exception:
-            exc_info = sys.exc_info()
-            self.fail("%s raised an unexpected exception type: "
-                      "expected=%s, actual=%s"
-                      % (callsig, exception, exc_info[0]))
-        else:
-            self.fail("%s did not raise %s" % (callsig, exception))
-
     def _assertRaisesMsgSubstring(self, excClass, msg, substring_match, callableObj, *args, **kwargs):
         try:
             callableObj(*args, **kwargs)
@@ -192,12 +149,6 @@ class BaseTestCase(unittest.TestCase):
         http://www.nedbatchelder.com/blog/200609.html#e20060905T064418
         """
         return self._assertRaisesMsgSubstring(excClass, msg, False, callableObj, *args, **kwargs)
-
-    def assertRaisesMsgSubstring(self, excClass, msg, callableObj, *args, **kwargs):
-        """
-        Just like assertRaisesMsg, but looks for substring in the message.
-        """
-        return self._assertRaisesMsgSubstring(excClass, msg, True, callableObj, *args, **kwargs)
 
     def do_equal_p(self, tests, att='cssText', debug=False, raising=True):
         """

--- a/css_parser_tests/basetest.py
+++ b/css_parser_tests/basetest.py
@@ -17,14 +17,6 @@ TEST_HOME = os.path.dirname(os.path.abspath(__file__))
 PY2x = sys.version_info < (3, 0)
 
 
-def msg3x(msg):
-    """msg might contain unicode repr `u'...'` which in py3 is `u'...`
-    needed by tests using ``assertRaisesMsg``"""
-    if not PY2x and msg.find("u'"):
-        msg = msg.replace("u'", "'")
-    return msg
-
-
 def get_resource_filename(resource_name):
     """Get the resource filename.
     """
@@ -106,49 +98,6 @@ class BaseTestCase(unittest.TestCase):
     def tearDown(self):
         if hasattr(self, '_ser'):
             self._restoreSer()
-
-    def _assertRaisesMsgSubstring(self, excClass, msg, substring_match, callableObj, *args, **kwargs):
-        try:
-            callableObj(*args, **kwargs)
-        except excClass as exc:
-            excMsg = str(exc)
-            if not msg:
-                # No message provided: any message is fine.
-                return
-            elif (msg in excMsg if substring_match else msg == excMsg):
-                # Message provided, and we got the right message: passes.
-                return
-            else:
-                # Message provided, and it didn't match: fail!
-                raise self.failureException(
-                    "Right exception, wrong message: got '%s' instead of '%s'" %
-                    (excMsg, msg))
-        else:
-            if hasattr(excClass, '__name__'):
-                excName = excClass.__name__
-            else:
-                excName = str(excClass)
-            raise self.failureException(
-                "Expected to raise %s, didn't get an exception at all" %
-                excName
-            )
-
-    def assertRaisesMsg(self, excClass, msg, callableObj, *args, **kwargs):
-        """
-        Just like unittest.TestCase.assertRaises,
-        but checks that the message is right too.
-
-        Usage::
-
-            self.assertRaisesMsg(
-                MyException, "Exception message",
-                my_function, arg1, arg2,
-                kwarg1=val, kwarg2=val)
-
-        from
-        http://www.nedbatchelder.com/blog/200609.html#e20060905T064418
-        """
-        return self._assertRaisesMsgSubstring(excClass, msg, False, callableObj, *args, **kwargs)
 
     def do_equal_p(self, tests, att='cssText', debug=False, raising=True):
         """

--- a/css_parser_tests/basetest.py
+++ b/css_parser_tests/basetest.py
@@ -32,6 +32,11 @@ def get_sheet_filename(sheet_name):
 
 class BaseTestCase(unittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        if not hasattr(cls, "assertRaisesRegex"):
+            setattr(cls, "assertRaisesRegex", cls.assertRaisesRegexp)
+
     def _tempSer(self):
         "Replace default ser with temp ser."
         self._ser = css_parser.ser

--- a/css_parser_tests/test_csscharsetrule.py
+++ b/css_parser_tests/test_csscharsetrule.py
@@ -42,14 +42,13 @@ class CSSCharsetRuleTestCase(test_cssrule.CSSRuleTestCase):
                     '@charset "%s";' % enc.lower(), r.cssText)
 
         for enc in (' ascii ', ' ascii', 'ascii '):
-            self.assertRaisesEx(xml.dom.SyntaxErr,
-                                css_parser.css.CSSCharsetRule, enc,
-                                exc_pattern=re.compile("Syntax Error"))
+            with self.assertRaisesRegex(xml.dom.SyntaxErr, r"Syntax Error"):
+                css_parser.css.CSSCharsetRule(enc)
 
         for enc in ('unknown', ):
-            self.assertRaisesEx(xml.dom.SyntaxErr,
-                                css_parser.css.CSSCharsetRule, enc,
-                                exc_pattern=re.compile(r"Unknown \(Python\) encoding"))
+            with self.assertRaisesRegex(xml.dom.SyntaxErr,
+                    r"Unknown \(Python\) encoding"):
+                css_parser.css.CSSCharsetRule(enc)
 
     def test_encoding(self):
         "CSSCharsetRule.encoding"
@@ -60,14 +59,13 @@ class CSSCharsetRuleTestCase(test_cssrule.CSSRuleTestCase):
                 '@charset "%s";' % enc.lower(), self.r.cssText)
 
         for enc in (None, ' ascii ', ' ascii', 'ascii '):
-            self.assertRaisesEx(xml.dom.SyntaxErr,
-                                self.r.__setattr__, 'encoding', enc,
-                                exc_pattern=re.compile("Syntax Error"))
+            with self.assertRaisesRegex(xml.dom.SyntaxErr, r"Syntax Error"):
+                self.r.__setattr__('encoding', enc)
 
         for enc in ('unknown', ):
-            self.assertRaisesEx(xml.dom.SyntaxErr,
-                                self.r.__setattr__, 'encoding', enc,
-                                exc_pattern=re.compile("Unknown \(Python\) encoding"))
+            with self.assertRaisesRegex(xml.dom.SyntaxErr,
+                    r"Unknown \(Python\) encoding"):
+                self.r.__setattr__('encoding', enc)
 
     def test_cssText(self):
         """CSSCharsetRule.cssText

--- a/css_parser_tests/test_cssimportrule.py
+++ b/css_parser_tests/test_cssimportrule.py
@@ -272,17 +272,17 @@ class CSSImportRuleTestCase(test_cssrule.CSSRuleTestCase):
         self.r.media.appendMedium('tv')
         self.assertEqual('@import url(x) print, tv;', self.r.cssText)
 
+        # for later exception handling
+        exc_msg = r'''MediaList: Ignoring new medium css_parser.stylesheets.MediaQuery\(mediaText='tv'\) as already specified "all" \(set ``mediaText`` instead\).'''
+
         # for generated rule
         r = css_parser.css.CSSImportRule(href='x')
-        self.assertRaisesMsg(xml.dom.InvalidModificationErr,
-                             basetest.msg3x(
-                                 '''MediaList: Ignoring new medium css_parser.stylesheets.MediaQuery(mediaText=u'tv') as already specified "all" (set ``mediaText`` instead).'''),
-                             r.media.appendMedium, 'tv')
+        with self.assertRaisesRegex(xml.dom.InvalidModificationErr, exc_msg):
+            r.media.appendMedium('tv')
         self.assertEqual('@import url(x);', r.cssText)
-        self.assertRaisesMsg(xml.dom.InvalidModificationErr,
-                             basetest.msg3x(
-                                 '''MediaList: Ignoring new medium css_parser.stylesheets.MediaQuery(mediaText=u'tv') as already specified "all" (set ``mediaText`` instead).'''),
-                             r.media.appendMedium, 'tv')
+
+        with self.assertRaisesRegex(xml.dom.InvalidModificationErr, exc_msg):
+            r.media.appendMedium('tv')
         self.assertEqual('@import url(x);', r.cssText)
         r.media.mediaText = 'tv'
         self.assertEqual('@import url(x) tv;', r.cssText)
@@ -293,15 +293,11 @@ class CSSImportRuleTestCase(test_cssrule.CSSRuleTestCase):
         s = css_parser.parseString('@import url(x);')
         r = s.cssRules[0]
 
-        self.assertRaisesMsg(xml.dom.InvalidModificationErr,
-                             basetest.msg3x(
-                                 '''MediaList: Ignoring new medium css_parser.stylesheets.MediaQuery(mediaText=u'tv') as already specified "all" (set ``mediaText`` instead).'''),
-                             r.media.appendMedium, 'tv')
+        with self.assertRaisesRegex(xml.dom.InvalidModificationErr, exc_msg):
+            r.media.appendMedium('tv')
         self.assertEqual('@import url(x);', r.cssText)
-        self.assertRaisesMsg(xml.dom.InvalidModificationErr,
-                             basetest.msg3x(
-                                 '''MediaList: Ignoring new medium css_parser.stylesheets.MediaQuery(mediaText=u'tv') as already specified "all" (set ``mediaText`` instead).'''),
-                             r.media.appendMedium, 'tv')
+        with self.assertRaisesRegex(xml.dom.InvalidModificationErr, exc_msg):
+            r.media.appendMedium('tv')
         self.assertEqual('@import url(x);', r.cssText)
         r.media.mediaText = 'tv'
         self.assertEqual('@import url(x) tv;', r.cssText)

--- a/css_parser_tests/test_cssimportrule.py
+++ b/css_parser_tests/test_cssimportrule.py
@@ -273,7 +273,8 @@ class CSSImportRuleTestCase(test_cssrule.CSSRuleTestCase):
         self.assertEqual('@import url(x) print, tv;', self.r.cssText)
 
         # for later exception handling
-        exc_msg = r'''MediaList: Ignoring new medium css_parser.stylesheets.MediaQuery\(mediaText='tv'\) as already specified "all" \(set ``mediaText`` instead\).'''
+        # u? is a superfluous attempt to be py2k compatible
+        exc_msg = r'''MediaList: Ignoring new medium css_parser.stylesheets.MediaQuery\(mediaText=u?'tv'\) as already specified "all" \(set ``mediaText`` instead\).'''
 
         # for generated rule
         r = css_parser.css.CSSImportRule(href='x')

--- a/css_parser_tests/test_cssstylesheet.py
+++ b/css_parser_tests/test_cssstylesheet.py
@@ -506,8 +506,9 @@ ex2|SEL4, a, ex2|SELSR {
         del s.namespaces.namespaces['p']
         self.assertEqual({'p': 'uri'}, s.namespaces.namespaces)
 
-        self.assertRaisesMsg(xml.dom.NamespaceErr, "Prefix undefined not found.",
-                             s.namespaces.__delitem__, 'undefined')
+        with self.assertRaisesRegex(xml.dom.NamespaceErr,
+                                    "Prefix undefined not found."):
+            s.namespaces.__delitem__('undefined')
 
     def test_namespaces5(self):
         "CSSStyleSheet.namespaces 5"
@@ -516,8 +517,9 @@ ex2|SEL4, a, ex2|SELSR {
         self.assertEqual(s.cssText, ''.encode())
 
         s = css_parser.css.CSSStyleSheet()
-        self.assertRaisesMsg(xml.dom.NamespaceErr, "Prefix a not found.",
-                             s._setCssText, 'a|a { color: red }')
+        with self.assertRaisesRegex(xml.dom.NamespaceErr,
+                                    "Prefix a not found."):
+            s._setCssText('a|a { color: red }')
 
     def test_deleteRuleIndex(self):
         "CSSStyleSheet.deleteRule(index)"

--- a/css_parser_tests/test_cssvalue.py
+++ b/css_parser_tests/test_cssvalue.py
@@ -568,11 +568,11 @@
 #                if type(exp) == types.TypeType or\
 #                   type(exp) == types.ClassType: # 2.4 compatibility
 #                    if cssText:
-#                        self.assertRaisesMsg(
-#                            exp, cssText, pv.setFloatValue, setType, setValue)
+#                        with self.assertRaisesRegex(exp, cssText):
+#                            pv.setFloatValue(setType, setValue)
 #                    else:
-#                        self.assertRaises(
-#                            exp, pv.setFloatValue, setType, setValue)
+#                        with self.assertRaises(exp):
+#                            pv.setFloatValue(setType, setValue)
 #                else:
 #                    pv.setFloatValue(setType, setValue)
 #                    self.assertEqual(pv._value[0], cssText)

--- a/css_parser_tests/test_medialist.py
+++ b/css_parser_tests/test_medialist.py
@@ -15,6 +15,7 @@ class MediaListTestCase(basetest.BaseTestCase):
     def setUp(self):
         super(MediaListTestCase, self).setUp()
         self.r = css_parser.stylesheets.MediaList()
+        self.exc_msg = r'''MediaList: Ignoring new medium css_parser.stylesheets.MediaQuery\(mediaText='tv'\) as already specified "all" \(set ``mediaText`` instead\).'''
 
     def test_set(self):
         "MediaList.mediaText 1"
@@ -27,9 +28,8 @@ class MediaListTestCase(basetest.BaseTestCase):
         self.assertEqual(2, ml.length)
         self.assertEqual('print, screen', ml.mediaText)
 
-        # self.assertRaisesMsg(xml.dom.InvalidModificationErr,
-        #                     basetest.msg3x('''MediaList: Ignoring new medium css_parser.stylesheets.MediaQuery(mediaText=u'tv') as already specified "all" (set ``mediaText`` instead).'''),
-        #                     ml._setMediaText, u' print , all  , tv ')
+        # with self.assertRaisesRegex(xml.dom.InvalidModificationErr, self.exc_msg):
+        #                     ml._setMediaText(u' print , all  , tv ')
         #
         #self.assertEqual(u'all', ml.mediaText)
         #self.assertEqual(1, ml.length)
@@ -89,24 +89,20 @@ class MediaListTestCase(basetest.BaseTestCase):
         self.assertEqual(1, ml.length)
         self.assertEqual('all', ml.mediaText)
 
-        self.assertRaisesMsg(xml.dom.InvalidModificationErr,
-                             basetest.msg3x(
-                                 '''MediaList: Ignoring new medium css_parser.stylesheets.MediaQuery(mediaText=u'tv') as already specified "all" (set ``mediaText`` instead).'''),
-                             ml.appendMedium, 'tv')
+        with self.assertRaisesRegex(xml.dom.InvalidModificationErr, self.exc_msg):
+            ml.appendMedium('tv')
         self.assertEqual(1, ml.length)
         self.assertEqual('all', ml.mediaText)
 
-        self.assertRaises(xml.dom.InvalidModificationErr,
-                          ml.appendMedium, 'test')
+        with self.assertRaises(xml.dom.InvalidModificationErr):
+            ml.appendMedium('test')
 
     def test_append2All(self):
         "MediaList all"
         ml = css_parser.stylesheets.MediaList()
         ml.appendMedium('all')
-        self.assertRaisesMsg(xml.dom.InvalidModificationErr,
-                             basetest.msg3x(
-                                 '''MediaList: Ignoring new medium css_parser.stylesheets.MediaQuery(mediaText=u'print') as already specified "all" (set ``mediaText`` instead).'''),
-                             ml.appendMedium, 'print')
+        with self.assertRaisesRegex(xml.dom.InvalidModificationErr, self.exc_msg.replace('tv', 'print')):
+            ml.appendMedium('print')
 
         sheet = css_parser.parseString('@media all, print { /**/ }')
         self.assertEqual('@media all {\n    /**/\n    }'.encode(), sheet.cssText)
@@ -144,9 +140,8 @@ class MediaListTestCase(basetest.BaseTestCase):
     #    self.assertEqual(2, ml.length)
     #    self.assertEqual(u'handheld, all', ml.mediaText)
 
-    #    self.assertRaisesMsg(xml.dom.InvalidModificationErr,
-    #                         basetest.msg3x('''MediaList: Ignoring new medium css_parser.stylesheets.MediaQuery(mediaText=u'handheld') as already specified "all" (set ``mediaText`` instead).'''),
-    #                         ml._setMediaText, u' handheld , all  , tv ')
+    #    with self.assertRaisesRegex(xml.dom.InvalidModificationErr, self.exc_msg):
+    #        ml._setMediaText(u' handheld , all  , tv ')
 
     def test_mediaText(self):
         "MediaList.mediaText 2"

--- a/css_parser_tests/test_medialist.py
+++ b/css_parser_tests/test_medialist.py
@@ -15,7 +15,9 @@ class MediaListTestCase(basetest.BaseTestCase):
     def setUp(self):
         super(MediaListTestCase, self).setUp()
         self.r = css_parser.stylesheets.MediaList()
-        self.exc_msg = r'''MediaList: Ignoring new medium css_parser.stylesheets.MediaQuery\(mediaText='tv'\) as already specified "all" \(set ``mediaText`` instead\).'''
+
+        # u? is a superfluous attempt to be py2k compatible
+        self.exc_msg = r'''MediaList: Ignoring new medium css_parser.stylesheets.MediaQuery\(mediaText=u?'tv'\) as already specified "all" \(set ``mediaText`` instead\).'''
 
     def test_set(self):
         "MediaList.mediaText 1"

--- a/css_parser_tests/test_profiles.py
+++ b/css_parser_tests/test_profiles.py
@@ -121,19 +121,17 @@ class ProfilesTestCase(basetest.BaseTestCase):
         css_parser.log.raiseExceptions = True
 
         # raises:
-        expmsg = "invalid literal for int() with base 10: 'x'"
-        # Python upto 2.4 and Jython have different msg format...
-        if sys.version_info[0:2] == (2, 4):
-            expmsg = "invalid literal for int(): x"
-        elif sys.platform.startswith('java'):
-            expmsg = "invalid literal for int() with base 10: x"
+        expmsg = r"invalid literal for int\(\) with base 10: 'x'"
+        # Jython have different msg format...
+        if sys.platform.startswith('java'):
+            expmsg = r"invalid literal for int\(\) with base 10: x"
         # PyPy adds the u prefix, but only in versions lower than Python 3
         elif (platform.python_implementation() == "PyPy" and
               sys.version_info < (3, 0)):
-            expmsg = "invalid literal for int() with base 10: u'x'"
+            expmsg = r"invalid literal for int\(\) with base 10: 'x'"
 
-        self.assertRaisesMsg(Exception, expmsg,
-                             css_parser.profile.validate, '-test-funcval', 'x')
+        with self.assertRaisesRegex(Exception, expmsg):
+            css_parser.profile.validate('-test-funcval', 'x')
 
     def test_removeProfile(self):
         "Profiles.removeProfile()"

--- a/css_parser_tests/test_property.py
+++ b/css_parser_tests/test_property.py
@@ -162,8 +162,8 @@ class PropertyTestCase(basetest.BaseTestCase):
         "Property.literalname"
         p = css_parser.css.property.Property(r'c\olor', 'red')
         self.assertEqual(r'c\olor', p.literalname)
-        self.assertRaisesMsgSubstring(AttributeError, "can't set attribute", p.__setattr__,
-                                      'literalname', 'color')
+        with self.assertRaisesRegex(AttributeError, r"can't set attribute"):
+            p.__setattr__('literalname', 'color')
 
     def test_validate(self):
         "Property.valid"

--- a/css_parser_tests/test_property.py
+++ b/css_parser_tests/test_property.py
@@ -93,25 +93,25 @@ class PropertyTestCase(basetest.BaseTestCase):
 
         tests = {
             '': (xml.dom.SyntaxErr,
-                  'Property: No property name found: '),
+                 'Property: No property name found: '),
             ':': (xml.dom.SyntaxErr,
-                   'Property: No property name found: : [1:1: :]'),
+                  r'Property: No property name found: : \[1:1: :\]'),
             'a': (xml.dom.SyntaxErr,
-                   'Property: No ":" after name found: a [1:1: a]'),
+                  r'Property: No ":" after name found: a \[1:1: a\]'),
             'b !': (xml.dom.SyntaxErr,
-                     'Property: No ":" after name found: b ! [1:3: !]'),
+                    r'Property: No ":" after name found: b ! \[1:3: !\]'),
             '/**/x': (xml.dom.SyntaxErr,
-                       'Property: No ":" after name found: /**/x [1:5: x]'),
+                      r'Property: No ":" after name found: /\*\*/x \[1:5: x\]'),
             'c:': (xml.dom.SyntaxErr,
-                    "Property: No property value found: c: [1:2: :]"),
+                   r"Property: No property value found: c: \[1:2: :\]"),
             'd: ': (xml.dom.SyntaxErr,
-                     "No content to parse."),
+                    r"No content to parse."),
             'e:!important': (xml.dom.SyntaxErr,
-                              "No content to parse."),
+                             r"No content to parse."),
             'f: 1!': (xml.dom.SyntaxErr,
-                       'Property: Invalid priority: !'),
+                      r'Property: Invalid priority: !'),
             'g: 1!importantX': (xml.dom.SyntaxErr,
-                                 "Property: No CSS priority value: importantx"),
+                                r"Property: No CSS priority value: importantx"),
 
             # TODO?
             # u'a: 1;': (xml.dom.SyntaxErr,
@@ -119,7 +119,8 @@ class PropertyTestCase(basetest.BaseTestCase):
         }
         for test in tests:
             ecp, msg = tests[test]
-            self.assertRaisesMsg(ecp, msg, p._setCssText, test)
+            with self.assertRaisesRegex(ecp, msg):
+                p._setCssText(test)
 
     def test_name(self):
         "Property.name"

--- a/css_parser_tests/test_selector.py
+++ b/css_parser_tests/test_selector.py
@@ -36,7 +36,8 @@ class SelectorTestCase(basetest.BaseTestCase):
         self.assertEqual((0, 0, 0, 1), s.specificity)
         self.assertEqual(True, s.wellformed)
 
-        self.assertRaisesEx(xml.dom.NamespaceErr, css_parser.css.Selector, 'p|b')
+        with self.assertRaises(xml.dom.NamespaceErr):
+            css_parser.css.Selector('p|b')
 
     def test_element(self):
         "Selector.element (TODO: RESOLVE)"
@@ -411,8 +412,8 @@ class SelectorTestCase(basetest.BaseTestCase):
         selector = css_parser.css.Selector()
 
         # readonly
-        def _set(): selector.specificity = 1
-        self.assertRaisesMsgSubstring(AttributeError, "can't set attribute", _set)
+        with self.assertRaisesRegex(AttributeError, r"can't set attribute"):
+            selector.specificity = 1
 
         tests = {
             '*': (0, 0, 0, 0),


### PR DESCRIPTION
There is no need to replicate badly assert methods which are already in the standard library.